### PR TITLE
Update process.shell to use a list rather than a multi-line string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added`
 
 ### `Fixed`
+- Update `process.shell` to use a list rather than a multi-line string https://nf-co.re/advisories/process-shell-configuration
 
 ### `Dependencies`
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -148,14 +148,13 @@ env {
 }
 
 // Set bash options
-process.shell = """\
-bash
-
-set -e # Exit if a tool returns a non-zero status/exit code
-set -u # Treat unset variables and parameters as an error
-set -o pipefail # Returns the status of the last command to exit with a non-zero status or zero if all successfully execute
-set -C # No clobber - prevent output redirection from overwriting files.
-"""
+process.shell = [
+    "bash",
+    "-C",         // No clobber - prevent output redirection from overwriting files.
+    "-e",         // Exit if a tool returns a non-zero status/exit code
+    "-u",         // Treat unset variables and parameters as an error
+    "-o pipefail" // Returns the status of the last command to exit with a non-zero status or zero if all successfully execute
+]
 
 // Disable process selector warnings by default. Use debug profile to enable warnings.
 nextflow.enable.configProcessNamesValidation = false


### PR DESCRIPTION
This issue originates from a previous version of the nf-core template https://nf-co.re/advisories/process-shell-configuration

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
